### PR TITLE
Fix/imagenet: use datasets 3.6.0

### DIFF
--- a/configs/imagenet.yaml
+++ b/configs/imagenet.yaml
@@ -3,7 +3,7 @@ num_classes: 1000
 in_channels: 3
 batch_size: 512
 start_lr: 0.01
-epochs: 300
+epochs: 100
 auto_augment: True
 rand_augment: True
 early_stopping: False

--- a/datamodules/imagenet.py
+++ b/datamodules/imagenet.py
@@ -42,7 +42,8 @@ class ImageNetDataModule(L.LightningDataModule):
         self.train_transform = v2.Compose(
             [
                 v2.ToImage(),
-                v2.Resize((config.train_res, config.train_res)),
+                v2.Resize((256, 256)),
+                v2.RandomCrop((config.train_res, config.train_res)),
                 (
                     v2.AutoAugment(v2.AutoAugmentPolicy.IMAGENET)
                     if config.auto_augment
@@ -56,7 +57,8 @@ class ImageNetDataModule(L.LightningDataModule):
         self.val_transform = v2.Compose(
             [
                 v2.ToImage(),
-                v2.Resize((config.val_res, config.val_res)),
+                v2.Resize((256, 256)),
+                v2.RandomCrop((config.val_res, config.val_res)),
                 v2.ToDtype(torch.float32, scale=True),
                 v2.Normalize(mean=IMAGENET_MEAN, std=IMAGENET_STD),
             ]
@@ -64,8 +66,8 @@ class ImageNetDataModule(L.LightningDataModule):
         self.test_transform = v2.Compose(
             [
                 v2.ToImage(),
-                v2.Resize((config.val_res, config.val_res)),
-                v2.TenCrop((config.val_res, config.val_res)),
+                v2.Resize((256, 256)),
+                v2.RandomCrop((config.val_res, config.val_res)),
                 v2.ToDtype(torch.float32, scale=True),
                 v2.Normalize(mean=IMAGENET_MEAN, std=IMAGENET_STD),
             ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "datasets>=3.5.0",
+    "datasets==3.6.0",
     "huggingface-hub>=0.30.2",
     "ipykernel>=6.29.5",
     "lightning>=2.5.1",


### PR DESCRIPTION
datasets has gotten rid of datasets with a script
since the hf imagenet dataset relies on a script, we need to use datasets v3.6.0