### PR TITLE
Feat/cifar resnet : ResNet models suited for cifar10

### DIFF
--- a/configs/cifar10.yaml
+++ b/configs/cifar10.yaml
@@ -1,9 +1,9 @@
 image_size: 32
 num_classes: 10
 in_channels: 3
-batch_size: 512
+batch_size: 256
 start_lr: 0.01
-epochs: 300
+epochs: 100
 early_stopping: False
 early_stopping_patience: 10
 auto_augment: True

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 from typing import Literal
+from models.cifar_resnet import cifar_resnet1202
 from task import BasicClassification, BasicSegmentation, BiSeNetV2Segmentation
-from models import LeNet, BasicNN, VGG16, SegNet, ResNet34, ResNet50, BiSeNetV2
+from models import LeNet, BasicNN, VGG16, SegNet, ResNet34, ResNet50, BiSeNetV2, cifar_resnet20, cifar_resnet32, cifar_resnet44, cifar_resnet56, cifar_resnet110
 from datamodules import (
     CIFAR10DataModule,
     MNISTDataModule,
@@ -74,9 +75,21 @@ def pick_model(model: str, in_channels: int, num_classes: int) -> nn.Module:
             return ResNet34(in_channels, num_classes)
         case "resnet50":
             return ResNet50(in_channels, num_classes)
+        case "cifar_resnet_20":
+            return cifar_resnet20(in_channels, num_classes)
+        case "cifar_resnet_32":
+            return cifar_resnet32(in_channels, num_classes)
+        case "cifar_resnet_44":
+            return cifar_resnet44(in_channels, num_classes)
+        case "cifar_resnet_56":
+            return cifar_resnet56(in_channels, num_classes)
+        case "cifar_resnet_110":
+            return cifar_resnet110(in_channels, num_classes)
+        case "cifar_resnet_1202":
+            return cifar_resnet1202(in_channels, num_classes)
         case _:
             raise NotImplementedError(
-                "The chosen model is invalid, please choose from the following: lenet, basic_nn, vgg16, segnet, resnet34, resnet50"
+                "The chosen model is invalid, please choose from the following: lenet, basic_nn, vgg16, segnet, resnet34, resnet50, cifar_resnet_{20, 32, 44, 56, 110, 1202}"
             )
 
 

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -3,4 +3,5 @@ from .lenet import LeNet
 from .vgg16 import VGG16
 from .segnet import SegNet
 from .resnet import ResNet34, ResNet50
+from .cifar_resnet import cifar_resnet20, cifar_resnet32, cifar_resnet44, cifar_resnet56, cifar_resnet110, cifar_resnet1202
 from .bisenet_v2 import BiSeNetV2

--- a/models/cifar_resnet.py
+++ b/models/cifar_resnet.py
@@ -1,0 +1,72 @@
+import torch.nn as nn
+from utils import create_conv_block, ResidualBlock
+from huggingface_hub import PyTorchModelHubMixin
+
+
+class CIFAR_ResNet(nn.Module, PyTorchModelHubMixin, pipeline_tag="image-classification", license="mit", tags=["arxiv:1512.03385"], repo_url="https://github.com/K-bNd/cv_101"):
+    def __init__(self, num_blocks: list[int], in_channels: int = 3, num_classes: int = 10):
+        super(CIFAR_ResNet, self).__init__()
+        self.in_channels = 16
+
+        self.conv1 = nn.Sequential(
+            *create_conv_block(in_channels=in_channels, out_channels=16, kernel_size=3, stride=1, padding=1)
+        )
+        self.layer1 = self._make_layer(16, num_blocks[0], stride=1)
+        self.layer2 = self._make_layer(32, num_blocks[1], stride=2)
+        self.layer3 = self._make_layer(64, num_blocks[2], stride=2)
+        self.pool = nn.AdaptiveAvgPool2d((1, 1))
+        self.classfier = nn.Sequential(
+            nn.Flatten(),
+            nn.Linear(in_features=64, out_features=num_classes),
+        )
+
+    def _make_layer(self, channels, num_blocks, stride):
+        strides = [stride] + [1] * (num_blocks - 1)
+        layers = []
+        for stride in strides:
+            layers.append(
+                ResidualBlock(
+                    in_channels=self.in_channels,
+                    out_channels=channels,
+                    kernel_size=3,
+                    stride=stride,
+                    padding=1,
+                    identity_shortcut=True,
+                )
+            )
+            self.in_channels = channels
+
+        return nn.Sequential(*layers)
+
+    def forward(self, x):
+        out = self.conv1(x)
+        out = self.layer1(out)
+        out = self.layer2(out)
+        out = self.layer3(out)
+        pool = self.pool(out)
+        logits = self.classfier(pool)
+        return logits
+
+
+def cifar_resnet20(in_channels: int = 3, num_classes: int = 10):
+    return CIFAR_ResNet([3, 3, 3], in_channels=in_channels, num_classes=num_classes)
+
+
+def cifar_resnet32(in_channels: int = 3, num_classes: int = 10):
+    return CIFAR_ResNet([5, 5, 5], in_channels=in_channels, num_classes=num_classes)
+
+
+def cifar_resnet44(in_channels: int = 3, num_classes: int = 10):
+    return CIFAR_ResNet([7, 7, 7], in_channels=in_channels, num_classes=num_classes)
+
+
+def cifar_resnet56(in_channels: int = 3, num_classes: int = 10):
+    return CIFAR_ResNet([9, 9, 9], in_channels=in_channels, num_classes=num_classes)
+
+
+def cifar_resnet110(in_channels: int = 3, num_classes: int = 10):
+    return CIFAR_ResNet([18, 18, 18], in_channels=in_channels, num_classes=num_classes)
+
+
+def cifar_resnet1202(in_channels: int = 3, num_classes: int = 10):
+    return CIFAR_ResNet([200, 200, 200], in_channels=in_channels, num_classes=num_classes)

--- a/models/resnet.py
+++ b/models/resnet.py
@@ -21,7 +21,7 @@ class ResNet50(nn.Module, PyTorchModelHubMixin, pipeline_tag="image-classificati
             # endregion
             # region conv2_x (56x56)
             BottleneckBlock(
-                in_channels=64, reduce_dim=64, out_channels=256, kernel_size=3, stride=1, padding=1
+                in_channels=64, reduce_dim=64, out_channels=256, kernel_size=3, stride=2, padding=1
             ),
             BottleneckBlock(
                 in_channels=256, reduce_dim=64, out_channels=256, kernel_size=3, stride=1, padding=1
@@ -32,7 +32,7 @@ class ResNet50(nn.Module, PyTorchModelHubMixin, pipeline_tag="image-classificati
             # endregion
             # region conv3_x (28x28)
             BottleneckBlock(
-                in_channels=256, reduce_dim=128, out_channels=512, kernel_size=3, stride=1, padding=1
+                in_channels=256, reduce_dim=128, out_channels=512, kernel_size=3, stride=2, padding=1
             ),
             BottleneckBlock(
                 in_channels=512, reduce_dim=128, out_channels=512, kernel_size=3, stride=1, padding=1
@@ -46,7 +46,7 @@ class ResNet50(nn.Module, PyTorchModelHubMixin, pipeline_tag="image-classificati
             # endregion
             # region conv4_x (14x14)
             BottleneckBlock(
-                in_channels=512, reduce_dim=256, out_channels=1024, kernel_size=3, stride=1, padding=1
+                in_channels=512, reduce_dim=256, out_channels=1024, kernel_size=3, stride=2, padding=1
             ),
             BottleneckBlock(
                 in_channels=1024, reduce_dim=256, out_channels=1024, kernel_size=3, stride=1, padding=1
@@ -66,7 +66,7 @@ class ResNet50(nn.Module, PyTorchModelHubMixin, pipeline_tag="image-classificati
             # endregion
             # region conv5_x (7x7)
             BottleneckBlock(
-                in_channels=1024, reduce_dim=512, out_channels=2048, kernel_size=3, stride=1, padding=1
+                in_channels=1024, reduce_dim=512, out_channels=2048, kernel_size=3, stride=2, padding=1
             ),
             BottleneckBlock(
                 in_channels=2048, reduce_dim=512, out_channels=2048, kernel_size=3, stride=1, padding=1
@@ -122,7 +122,7 @@ class ResNet34(nn.Module, PyTorchModelHubMixin, pipeline_tag="image-classificati
             # endregion
             # region conv3_x
             ResidualBlock(
-                in_channels=64, out_channels=128, kernel_size=3, stride=1, padding=1
+                in_channels=64, out_channels=128, kernel_size=3, stride=2, padding=1
             ),
             ResidualBlock(
                 in_channels=128, out_channels=128, kernel_size=3, stride=1, padding=1
@@ -136,7 +136,7 @@ class ResNet34(nn.Module, PyTorchModelHubMixin, pipeline_tag="image-classificati
             # endregion
             # region conv4_x
             ResidualBlock(
-                in_channels=128, out_channels=256, kernel_size=3, stride=1, padding=1
+                in_channels=128, out_channels=256, kernel_size=3, stride=2, padding=1
             ),
             ResidualBlock(
                 in_channels=256, out_channels=256, kernel_size=3, stride=1, padding=1
@@ -156,7 +156,7 @@ class ResNet34(nn.Module, PyTorchModelHubMixin, pipeline_tag="image-classificati
             # endregion
             # region conv5_x
             ResidualBlock(
-                in_channels=256, out_channels=512, kernel_size=3, stride=1, padding=1
+                in_channels=256, out_channels=512, kernel_size=3, stride=2, padding=1
             ),
             ResidualBlock(
                 in_channels=512, out_channels=512, kernel_size=3, stride=1, padding=1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "datasets>=3.5.0",
+    "datasets==3.6.0",
     "huggingface-hub>=0.30.2",
     "ipykernel>=6.29.5",
     "lightning>=2.5.1",
@@ -13,6 +13,7 @@ dependencies = [
     "tensorboard>=2.19.0",
     "timm>=1.0.16",
     "torch>=2.6.0",
+    "torchinfo>=1.8.0",
     "torchvision>=0.21.0",
     "wandb>=0.19.9",
 ]

--- a/utils/conv_utils.py
+++ b/utils/conv_utils.py
@@ -52,6 +52,7 @@ class ResidualBlock(nn.Module):
                     out_channels=out_channels,
                     kernel_size=1,
                     stride=2,
+                    relu=False
                 )
             )
             if in_channels != out_channels
@@ -71,12 +72,13 @@ class ResidualBlock(nn.Module):
                 kernel_size=kernel_size,
                 stride=stride,
                 padding=padding,
+                relu=False
             ),
         )
 
     def forward(self, x: torch.Tensor):
         out = self.conv(x)
-        return out + self.shortcut(x)
+        return torch.nn.functional.relu(out + self.shortcut(x))
 
 
 class BottleneckBlock(nn.Module):
@@ -102,6 +104,7 @@ class BottleneckBlock(nn.Module):
                     out_channels=out_channels,
                     kernel_size=1,
                     stride=2,
+                    relu=False
                 )
             )
             if in_channels != out_channels
@@ -129,12 +132,13 @@ class BottleneckBlock(nn.Module):
                 kernel_size=1,
                 stride=1,
                 padding=0,
+                relu=False
             ),
         )
 
     def forward(self, x: torch.Tensor):
         out = self.conv(x)
-        return out + self.shortcut(x)
+        return torch.nn.functional.relu(out + self.shortcut(x))
 
 
 # endregion


### PR DESCRIPTION
- small rework on Residual blocks and Bottleneck blocks (stride properly defined)
- use actual cifar10 values for normalisation
- add padded randomcrop for train transform
- freeze datasets version for imagenet (should be on master though..)